### PR TITLE
gh 2.83.1

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,18 +1,16 @@
-:: Turn work folder into GOPATH
-set GOPATH=%SRC_DR%
-set PATH=%GOPATH%\bin:%PATH%
+@echo on
 
 :: Change to directory with main.go
-cd cmd\gh
+cd /d "%SRC_DIR%\cmd\gh"
 if errorlevel 1 exit 1
 
 :: Build
-go build -v -o %PKG_NAME%.exe .
+go build -v -o "%PKG_NAME%.exe" .
 if errorlevel 1 exit 1
 
 :: Install Binary into %SCRIPTS%
-if not exist %SCRIPTS% mkdir %SCRIPTS%
+if not exist "%SCRIPTS%" mkdir "%SCRIPTS%"
 if errorlevel 1 exit 1
 
-mv %PKG_NAME% %SCRIPTS%\%PKG_NAME%
+move "%PKG_NAME%.exe" "%SCRIPTS%\%PKG_NAME%.exe"
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,11 +5,11 @@ export GOPATH=$SRC_DR
 export PATH=${GOPATH}/bin:$PATH
 
 # Change to directory with main.go
-pushd cmd/gh
+pushd cmd/gh || exit
 
 # Build
-go build -v -o ${PKG_NAME} .
+go build -v -o "${PKG_NAME}" .
 
 # Install Binary into PREFIX/bin
-mkdir -p $PREFIX/bin
-mv ${PKG_NAME} $PREFIX/bin/${PKG_NAME}
+mkdir -p "$PREFIX"/bin
+mv "${PKG_NAME}" "$PREFIX"/bin/"${PKG_NAME}"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 
-# Turn work folder into GOPATH
-export GOPATH=$SRC_DR
-export PATH=${GOPATH}/bin:$PATH
-
 # Change to directory with main.go
 pushd cmd/gh || exit
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "gh" %}
-{% set version = "2.68.1" %}
+{% set version = "2.83.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,18 +7,18 @@ package:
 
 source:
   url: https://github.com/cli/cli/archive/v{{ version }}.tar.gz
-  sha256: 520ab7ca5eda31af4aab717e1f9bc65497cdc23a46f71dab56d47513e00c7b82
+  sha256: 5053825b631fa240bba1bfdb3de6ac2c7af5e3c7884b755a6a5764994d02f999
 
 build:
   number: 0
-  # nothing provides requested go_linux-s390x
-  skip: true  # [s390x]
   script_env:
     - GH_VERSION=v{{ version }}
 
 requirements:
   build:
     - {{ compiler('go') }}
+    - {{ stdlib("c") }}
+    - make  # [unix]
 
 test:
   commands:
@@ -34,7 +34,7 @@ about:
   description: |
     gh is GitHub on the command line. It brings pull requests, issues,
     and other GitHub concepts to the terminal next to where you are already working with git and your code.
-  doc_url: https://cli.github.com/
+  doc_url: https://cli.github.com
   dev_url: https://github.com/cli/cli
 
 extra:


### PR DESCRIPTION
gh 2.83.1

**Destination channel:** {defaults}

### Links

- [{PKG-6248}](https://anaconda.atlassian.net/browse/PKG-6248) 
- https://github.com/cli/cli
- https://github.com/cli/cli/tree/v2.83.1

### Explanation of changes:

- version updated 2.68.1 → 2.83.1
- build.sh: added safety/quoting
- about: normalized doc_url (removed trailing slash)
- rm GOPATH, no need if go uses go modules